### PR TITLE
feat: create login logic in models and add initial tables with connec…

### DIFF
--- a/app/Adms/Controllers/Dashboard.php
+++ b/app/Adms/Controllers/Dashboard.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Adms\Controllers;
+
+use App\adms\Models\helpers\SidebarMenuPermissions;
+use Core\ConfigView;
+
+class Dashboard 
+{
+    private array|string|null $data;
+
+    public function index(): void
+    {
+        $this->data['welcome'] = "Bem Vindo(a), {$_SESSION['user_name']}!";
+        // $this->data['sidebar_menu'] = SidebarMenuPermissions::checkPermissionsSidebarMenus();
+
+        $view = new ConfigView("Adms/Views/dashboard/dashboard", $this->data);
+        $view->loadView();
+    }
+}

--- a/app/Adms/Controllers/Login.php
+++ b/app/Adms/Controllers/Login.php
@@ -11,8 +11,8 @@ class Login
     public function index(): void
     {
         $formData = filter_input_array(INPUT_POST, FILTER_DEFAULT);
-
-        if (! empty($this->formData['sendLogin'])) {
+       
+        if (! empty($formData['sendLogin'])) {
             $validateLogin = new AdmsLogin();
             $validateLogin->login($formData);
             
@@ -21,7 +21,7 @@ class Login
             }  
         } 
 
-        $view = new ConfigView("Adms/Views/login/login", null);
+        $view = new ConfigView("Adms/Views/login/login");
         $view->loadViewLogin();
     }
 }

--- a/app/Adms/Enum/UserSituation.php
+++ b/app/Adms/Enum/UserSituation.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Adms\Enum;
+
+enum UserSituation: int
+{
+    case CONFIRMED_EMAIL = 1;
+    case WAITING_FOR_CONFIRMATION = 2; 
+    case NOT_REGISTERED = 3;
+}

--- a/app/Adms/Models/AdmsLogin.php
+++ b/app/Adms/Models/AdmsLogin.php
@@ -2,21 +2,90 @@
 
 namespace App\Adms\Models;
 
-use PDO;
+use App\Adms\Enum\UserSituation;
 use App\Helpers\Connection;
+use Core\Config;
+use PDO;
 
 class AdmsLogin
 {
-    private ?array $data;
-    private object $conn;
+    private ?array $data = null;
     private bool $result = false;
+    private PDO $conn;
+
+    public function __construct()
+    {
+        $this->conn = Connection::connect(Config::db());
+    }
 
     public function getResult(): bool
     {
         return $this->result;
     }
 
-    public function login(array $data = null): void
+    public function login(array $data): void
     {
+        $this->data = $data;
+        $sqlUser = $this->conn->prepare(query: $this->validateUser());
+        $sqlUser->bindValue(param: ':user', value: trim($this->data['user']), type: PDO::PARAM_STR);
+        $sqlUser->execute();
+        $resultUser = $sqlUser->fetch();
+
+        if ($resultUser) {
+            $this->validateIfEmailConfirm($resultUser);
+        } 
+        else {
+            $_SESSION['msg'] = "<div class='alert alert-danger'>Usuário ou senha incorretos</div>";
+            $this->result = false;
+        }
+    }
+
+    private function validateUser(): string
+    {
+        return "SELECT 
+                    user.id, user.name, user.nickname,
+                    user.email, user.password, user.image,
+                    user.user_situation_id, user.access_level_id, 
+                    access.order_level
+                FROM `users` AS user
+                INNER JOIN `access_levels` AS access
+                    ON user.access_level_id = access.id
+                    WHERE UPPER(`user`) = UPPER(:user)
+                    LIMIT 1";
+    }
+
+    private function validatePassword(?array $resultUser): void
+    {
+        if (password_verify($this->data['password'], $resultUser['password'])) {
+            $_SESSION['user_id']            = $resultUser['id'];
+            $_SESSION['user_name']          = $resultUser['name'];
+            $_SESSION['user_nickname']      = $resultUser['nickname'];
+            $_SESSION['user_email']         = $resultUser['email'];
+            $_SESSION['user_image']         = $resultUser['image'];
+            $_SESSION['user_situation_id']  = $resultUser['user_situation_id'];
+            $_SESSION['access_level']       = $resultUser['access_level_id'];
+            $_SESSION['order_level']        = $resultUser['order_level'];
+            $this->result = true;
+        }
+        else {
+            $_SESSION['msg'] = "<div class='alert alert-danger'>Usuário ou senha incorretos</div>";
+            $this->result = false;
+        }
+    }
+
+    private function validateIfEmailConfirm(array $resultUser): void
+    {
+        $userSituationId = $resultUser['user_situation_id'];
+        $message = "";
+
+        $message = match ($userSituationId) {
+            UserSituation::CONFIRMED_EMAIL->value => $this->validatePassword($resultUser),
+            UserSituation::WAITING_FOR_CONFIRMATION->value => "<div class='alert alert-danger'>Você precisa confirmar seu e-mail para acessar. 
+            Clique <a href='" . Config::url() . "new-confirm-email/index'> aqui </a> para reenviar o e-mail de confirmação.</div>",
+            UserSituation::NOT_REGISTERED->value => "<div class='alert alert-danger'>Usuário não cadastrado. Entre em contato com a empresa</div>",
+            default => "<div class='alert alert-danger'>Usuário inativo. Entre em contato com a empresa</div>",
+        };
+    
+        $_SESSION['msg'] = $message;
     }
 }

--- a/app/Adms/Views/dashboard/dashboard.php
+++ b/app/Adms/Views/dashboard/dashboard.php
@@ -1,0 +1,3 @@
+<?php
+echo $this->data['welcome'];
+echo "<br><br>Dashboard!<br><br>";

--- a/app/Helpers/Connection.php
+++ b/app/Helpers/Connection.php
@@ -1,8 +1,37 @@
 <?php
 
-namespace App\Adms\helpers;
+namespace App\Helpers;
 
-class Connection 
+use Core\Config;
+use PDO;
+use PDOException;
+
+final class Connection 
 {
+    private static ?PDO $connect = null;
 
+    public static function connect(array $db): PDO
+    {
+        if (self::$connect === null) {
+            try {
+                self::$connect = new PDO(
+                    'mysql:host=' . $db['host'] . ';dbname=' . $db['database'] . ';port=' . $db['port'],
+                    $db['user'],
+                    $db['password'],
+                    [
+                        PDO::ATTR_ERRMODE          => PDO::ERRMODE_EXCEPTION, 
+                        PDO::ATTR_EMULATE_PREPARES => false, 
+                    ]
+                );
+            } 
+            catch (PDOException $error) {
+                die(
+                    "Erro Código: {$error->getCode()}. <br>
+                    Entre em contato com o administrador: " . Config::admEmail()
+                );
+            }
+        }
+        
+        return self::$connect;
+    }
 }

--- a/core/ConfigView.php
+++ b/core/ConfigView.php
@@ -4,7 +4,7 @@ namespace Core;
 
 class ConfigView
 {
-    public function __construct(private string $nameView, private array|string|null $data)
+    public function __construct(private string $nameView, private ?array $data = [])
     {
     }
 

--- a/sql/mysql/init.sql
+++ b/sql/mysql/init.sql
@@ -4,3 +4,71 @@ CREATE DATABASE sgs
 
 SET NAMES utf8mb4;
 USE sgs;
+
+CREATE TABLE `access_levels` (
+    `id` INT NOT NULL AUTO_INCREMENT,
+    `access_level` VARCHAR(100) NOT NULL,
+    `order_level` INT NOT NULL,
+    `created_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `updated_at` TIMESTAMP NULL DEFAULT NULL,
+    PRIMARY KEY (`id`)
+) ENGINE=InnoDB;
+
+CREATE TABLE `config_emails` (
+    `id` INT NOT NULL AUTO_INCREMENT,
+    `title` VARCHAR(225) NOT NULL,
+    `name` VARCHAR(225) NOT NULL,
+    `email` VARCHAR(225) NOT NULL,
+    `host` VARCHAR(225) NOT NULL,
+    `username` VARCHAR(225) NOT NULL,
+    `password` VARCHAR(225) NOT NULL,
+    `smtp_secure` VARCHAR(225) NOT NULL,
+    `port` INT NOT NULL,
+    `created_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `updated_at` TIMESTAMP NULL DEFAULT NULL,
+    PRIMARY KEY (`id`)
+) ENGINE=InnoDB;
+
+CREATE TABLE `colors`(
+    `id` INT NOT NULL AUTO_INCREMENT,
+    `color_name` VARCHAR(100) NOT NULL,
+    `color` VARCHAR(100) NOT NULL,
+    `created_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `updated_at` TIMESTAMP NULL DEFAULT NULL,
+    PRIMARY KEY (`id`)
+) ENGINE=InnoDB;
+
+CREATE TABLE `users_situation`(
+    `id` INT NOT NULL AUTO_INCREMENT,
+    `situation_name` VARCHAR(100) NOT NULL,
+    `color_id` INT NOT NULL,
+    `created_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `updated_at` TIMESTAMP NULL DEFAULT NULL,
+    PRIMARY KEY (`id`),
+    CONSTRAINT `fk_user_situation_with_color_id`
+    FOREIGN KEY (`color_id`) REFERENCES `colors`(`id`) 
+    ON DELETE RESTRICT ON UPDATE CASCADE
+) ENGINE=InnoDB;
+
+CREATE TABLE `users` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `name` varchar(100) NOT NULL,
+  `nickname` varchar(100) NULL,
+  `email` varchar(100) UNIQUE NOT NULL,
+  `user` varchar(100) UNIQUE NOT NULL,
+  `password` varchar(255) NOT NULL,
+  `recover_password` varchar(255) NULL,
+  `image` varchar(255) NULL,
+  `confirm_email` VARCHAR(225) NULL,
+  `user_situation_id` INT NOT NULL,
+  `access_level_id` INT NOT NULL,
+  `created_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` TIMESTAMP NULL DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  CONSTRAINT `fk_users_with_user_situation_id`
+  FOREIGN KEY (`user_situation_id`) REFERENCES `users_situation`(`id`) 
+    ON DELETE RESTRICT ON UPDATE CASCADE,
+  CONSTRAINT `fk_users_with_access_level_id`
+  FOREIGN KEY (`access_level_id`) REFERENCES `access_levels`(`id`)
+    ON DELETE RESTRICT ON UPDATE CASCADE
+) ENGINE=InnoDB;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches authentication/session flow and database connectivity; also changes `ConfigView` constructor typing which may break existing callers that pass non-arrays (e.g. error view).
> 
> **Overview**
> Adds an initial `Dashboard` controller/view that renders a welcome message for the logged-in user.
> 
> Reworks login to validate credentials via a new DB-backed `AdmsLogin` model: it fetches the user/access level, verifies the password, sets key session fields, and blocks access based on `UserSituation` (confirmed email vs pending/inactive) with appropriate messages.
> 
> Introduces a shared `Connection` helper (with centralized PDO config/error handling), updates `ConfigView` to default `data` to an array, and expands `sql/mysql/init.sql` with initial schema for `users`, `access_levels`, `users_situation`, `colors`, and `config_emails`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 046cee807b4210a1d0a592d33dd63bafa2604b06. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->